### PR TITLE
Link repository names on About page

### DIFF
--- a/src/javascript/components/About.js
+++ b/src/javascript/components/About.js
@@ -18,11 +18,11 @@ export default class About extends React.Component{
           <h2><i className="fa fa-github" /> Contribute</h2>
           <div className="row">
             <div className="col-md-6">
-              The linter is available at replicatedhq/dockerfilelint<br />
+              The linter is available at <a href="https://github.com/replicatedhq/dockerfilelint">replicatedhq/dockerfilelint</a><br />
               <iframe src="https://ghbtns.com/github-btn.html?user=replicatedhq&repo=dockerfilelint&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px"></iframe>
             </div>
             <div className="col-md-6">
-              This site is available at replicatedhq/fromlatest.io<br />
+              This site is available at <a href="https://github.com/replicatedhq/fromlatest.io">replicatedhq/fromlatest.io</a><br />
               <iframe src="https://ghbtns.com/github-btn.html?user=replicatedhq&repo=fromlatest.io&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px"></iframe>
             </div>
           </div>


### PR DESCRIPTION
I know the Contribute button is in the top right, but when on the About page and seeing the sections for the linter tool and the site, being unable to click anything to browse to them was a nuisance, so here we are!